### PR TITLE
uses environment variable to specify load test host

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -334,20 +334,6 @@ jobs:
           inlineScript: |
             #!/bin/bash
             az role assignment create --assignee "rpagels@microsoft.com" --role "Load Test Contributor" --resource-group ${{ env.Azure_Resource_GroupName }}
-
-      # Update JMX file with Website URL
-      - name: Update JMX File webAppUrl
-        uses: Azure/powershell@v1
-        continue-on-error: false
-        id: setWebsiteUrl
-        env:
-          POWERSHELL_TELEMETRY_OPTOUT: 1
-        with:
-          inlineScript: MercuryHealth.LoadTests/TransformJMXFile.ps1 -website_url ${{needs.deploy_to_environment.outputs.output1}}
-          # Azure PS version to be used to execute the script, example: 1.8.0, 2.8.0, 3.4.0. To use the latest version, specify "latest".
-          azPSVersion: latest
-          # Select the value of the ErrorActionPreference variable for executing the script. Options: stop, continue, silentlyContinue. Default is Stop.
-          errorActionPreference: continue
           
       - name: 'Azure Load Testing'
         uses: azure/load-testing@v1
@@ -356,6 +342,13 @@ jobs:
           loadTestConfigFile: './MercuryHealth.LoadTests/LoadTest_HomePage_Config.yaml'
           loadTestResource: ${{needs.deploy_to_environment.outputs.output3}}
           resourceGroup: ${{ env.Azure_Resource_GroupName }}
+          env: |
+          [
+            {
+              "name": "webHost",
+              "value": ${{needs.deploy_to_environment.outputs.output1}}
+            }
+          ]
 
       - name: Azure logout
         run: |

--- a/MercuryHealth.LoadTests/LoadTest_HomePage.jmx
+++ b/MercuryHealth.LoadTests/LoadTest_HomePage.jmx
@@ -7,7 +7,14 @@
       <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
       <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-        <collectionProp name="Arguments.arguments"/>
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="appToken" elementType="Argument">
+            <stringProp name="Argument.name">udv_webHost</stringProp>
+            <stringProp name="Argument.value">${__BeanShell( System.getenv("webHost") )}</stringProp>
+            <stringProp name="Argument.desc">Web app URL</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
       </elementProp>
       <stringProp name="TestPlan.user_define_classpath"></stringProp>
     </TestPlan>
@@ -30,7 +37,7 @@
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
-          <stringProp name="HTTPSampler.domain">WebSiteUrlHere</stringProp>
+          <stringProp name="HTTPSampler.domain">${udv_webHost}</stringProp>
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>


### PR DESCRIPTION
I haven't been able to get the CI/CD working on my fork, so this needs to be tested before integration. Reference used was https://docs.microsoft.com/en-us/azure/load-testing/how-to-parameterize-load-tests